### PR TITLE
Fixes to riglevel. &OPUS

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ defaults = dict(
    ),
    gameMinute=6.67,
    level=dict(
-      target = -3.0
+      target = -1.0
    ),
    match="Group"
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+altgraph==0.17.4
+importlib_metadata==8.5.0
+Nuitka==2.7.12
+ordered-set==4.1.0
+packaging==25.0
+pefile==2023.2.7
+pydub==0.25.1
+pyinstaller==6.14.2
+pyinstaller-hooks-contrib==2025.7
+python-vlc==3.0.21203
+pywin32-ctypes==0.2.3
+PyYAML==6.0.2
+zipp==3.20.2
+zstandard==0.23.0

--- a/rigdj.py
+++ b/rigdj.py
@@ -216,7 +216,7 @@ class SongRow:
 
    def openFile (self):
       # get a file
-      filename = filedialog.askopenfilename(filetypes = (("Music files", "*.mp3 *.ogg, *.flac *.m4a *.wav"),("All files","*")))
+      filename = filedialog.askopenfilename(filetypes = (("Music files", "*.mp3 *.ogg *.opus *.flac *.m4a *.wav"),("All files","*")))
       # insert into songNameEntry (callback automatically invoked)
       self.songNameEntry.delete(0,END)
       self.songNameEntry.insert(0,filename)

--- a/riglevel.py
+++ b/riglevel.py
@@ -52,7 +52,7 @@ class Riglevel (Frame):
       self.progressbar = ttk.Progressbar(self, variable=self.progress, length=250)
       self.progressbar.grid(row=6, columnspan=2, pady=5)
 
-      self.audioFileTypes = [".mp3", ".ogg", ".flac", ".m4a", ".wav"]
+      self.audioFileTypes = [".mp3", ".ogg", ".opus", ".flac", ".m4a", ".wav"]
       self.validArr = []
       self.thread = None
 

--- a/riglevel.py
+++ b/riglevel.py
@@ -73,7 +73,7 @@ class Riglevel (Frame):
                if ext in self.audioFileTypes and not name.endswith("_normalized"):
                   songArr.append(file)
       else:
-         f = filedialog.askopenfilename(filetypes = (("Music files", "*.mp3 *.ogg, *.flac *.m4a *.wav"),("All files","*")))
+         f = filedialog.askopenfilename(filetypes = (("Music files", "*.mp3 *.ogg *.opus *.flac *.m4a *.wav"),("All files","*")))
          # leave function if user cancels dialog
          if f == "": return
 
@@ -151,14 +151,14 @@ class Riglevel (Frame):
             self.thread = None
             return
          # normalize song to specified dBFS level
-         change = target - sound.dBFS
-         print("   File has volume {} dBFS, target is {} dBFS; applying {} dBFS gain.".format(sound.dBFS, target, change))
+         change = target - sound.max_dBFS
+         print("   File has peak of {} dBFS, target is {} dBFS; applying {} dBFS gain.".format(sound.max_dBFS, target, change))
          output = sound.apply_gain(change)
 
          # export normalized song
-         outfile = name + "_normalized.mp3"
+         outfile = name + "_normalized.opus"
          print("   Writing normalised file to {}".format(outfile))
-         output.export(outfile, "mp3", bitrate="192k")
+         output.export(outfile, format="opus", parameters=["-c:a", "libopus", "-b:a", "160k"])
 
          # tick up the counter and update progress bar accordingly
          count += 1

--- a/version.py
+++ b/version.py
@@ -1,3 +1,3 @@
 rigdio_version = "v1.18.3"
-rigdj_version = "v1.13.1"
-riglevel_version = "v0.1.0"
+rigdj_version = "v1.13.2"
+riglevel_version = "v0.2.0"


### PR DESCRIPTION
### Major
Changed how normalization is done.

riglevel 0.1.0's normalization isn't exactly normalization. It'd be perfect if everyone put -18 (or -23). I do mean everyone, because then it'd just sound like every audio export had been through ReplayGain. But even that would still be problematic without some extra work. Playback with ReplayGain (in foobar2000 or whatever else people use) respects peak levels by default and avoids clipping during playback. Having everyone use a good value for the current version (-23 - -14) still wouldn't - and clipping would always be possible. I'm not familiar enough with pydub to implement proper "mean" volume leveling that respects peak levels, it's far easier to just normalize based on the peak level itself. Exactly like "Normalize" would function in Audacity or something, and what I imagine most people expect when they see "Normalize". You can put 0 in. No clipping ever.

Also changed the riglevel output to .opus because ffmpeg's default MP3 encoder is absolutely awful. Their opus encoder is awful too, so libopus is called specifically. Could still use MP3 if you force LAME, if libmp3lame is included in ffmpeg `output.export(outfile, format="mp3", parameters=["-c:a", "libmp3lame", "-q:a", "0"])`

### Minor
Added .opus import "support" to rigdj. rigdio itself has been able to play it forever, but rigdj wouldn't show it without renaming to .ogg or viewing "All files"